### PR TITLE
chore: remove depcheck from global install and uninstall scripts

### DIFF
--- a/scripts/npm.global.install.sh
+++ b/scripts/npm.global.install.sh
@@ -7,7 +7,6 @@ cd "$HOME" || exit
 npm install --global \
   @donniean/configs \
   concurrently \
-  depcheck \
   npm-check-updates \
   serve \
   sort-package-json \

--- a/scripts/npm.global.uninstall.sh
+++ b/scripts/npm.global.uninstall.sh
@@ -8,7 +8,6 @@ npm uninstall --global \
   @donniean/configs \
   concurrently \
   corepack \
-  depcheck \
   npm-check-updates \
   serve \
   sort-package-json \


### PR DESCRIPTION
Eliminate depcheck from the global installation and uninstallation processes to streamline dependencies.