### PR TITLE
chore(scripts): add timestamped PS4 debug output

### DIFF
--- a/scripts/brew.upgrade.sh
+++ b/scripts/brew.upgrade.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-export PS4='+CMD [${BASH_SOURCE##*/}:${LINENO}] '
+export PS4=$'\n+CMD [\\D{%Y-%m-%dT%H:%M:%S%z}] [${BASH_SOURCE##*/}:${LINENO}] '
 
 set -x
 

--- a/scripts/brew.upgrade.sh
+++ b/scripts/brew.upgrade.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-export PS4=$'\n+CMD [\\D{%Y-%m-%dT%H:%M:%S%z}] [${BASH_SOURCE##*/}:${LINENO}] '
+export PS4=$'\n+CMD [\D{%Y-%m-%dT%H:%M:%S%z}] [${BASH_SOURCE##*/}:${LINENO}] '
 
 set -x
 

--- a/scripts/brew.upgrade.sh
+++ b/scripts/brew.upgrade.sh
@@ -6,8 +6,6 @@ export PS4=$'\n+CMD [\D{%Y-%m-%dT%H:%M:%S%z}] [${BASH_SOURCE##*/}:${LINENO}] '
 
 set -x
 
-date '+%Y-%m-%dT%H:%M:%S%z'
-
 brew tap-info
 brew tap
 

--- a/scripts/codex.sh
+++ b/scripts/codex.sh
@@ -2,7 +2,7 @@
 
 set -uo pipefail
 
-export PS4='+CMD [${BASH_SOURCE##*/}:${LINENO}] '
+export PS4=$'\n+CMD [\\D{%Y-%m-%dT%H:%M:%S%z}] [${BASH_SOURCE##*/}:${LINENO}] '
 
 set -x
 

--- a/scripts/codex.sh
+++ b/scripts/codex.sh
@@ -6,8 +6,6 @@ export PS4=$'\n+CMD [\D{%Y-%m-%dT%H:%M:%S%z}] [${BASH_SOURCE##*/}:${LINENO}] '
 
 set -x
 
-date '+%Y-%m-%dT%H:%M:%S%z'
-
 brew info codex
 brew info codex-app
 

--- a/scripts/codex.sh
+++ b/scripts/codex.sh
@@ -2,7 +2,7 @@
 
 set -uo pipefail
 
-export PS4=$'\n+CMD [\\D{%Y-%m-%dT%H:%M:%S%z}] [${BASH_SOURCE##*/}:${LINENO}] '
+export PS4=$'\n+CMD [\D{%Y-%m-%dT%H:%M:%S%z}] [${BASH_SOURCE##*/}:${LINENO}] '
 
 set -x
 

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -2,7 +2,7 @@
 
 set -uo pipefail
 
-export PS4='+CMD [${BASH_SOURCE##*/}:${LINENO}] '
+export PS4=$'\n+CMD [\\D{%Y-%m-%dT%H:%M:%S%z}] [${BASH_SOURCE##*/}:${LINENO}] '
 
 set -x
 

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -2,7 +2,7 @@
 
 set -uo pipefail
 
-export PS4=$'\n+CMD [\\D{%Y-%m-%dT%H:%M:%S%z}] [${BASH_SOURCE##*/}:${LINENO}] '
+export PS4=$'\n+CMD [\D{%Y-%m-%dT%H:%M:%S%z}] [${BASH_SOURCE##*/}:${LINENO}] '
 
 set -x
 

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -6,8 +6,6 @@ export PS4=$'\n+CMD [\D{%Y-%m-%dT%H:%M:%S%z}] [${BASH_SOURCE##*/}:${LINENO}] '
 
 set -x
 
-date '+%Y-%m-%dT%H:%M:%S%z'
-
 type -a ast-grep
 ast-grep --version
 

--- a/scripts/mas.update.sh
+++ b/scripts/mas.update.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-export PS4='+CMD [${BASH_SOURCE##*/}:${LINENO}] '
+export PS4=$'\n+CMD [\\D{%Y-%m-%dT%H:%M:%S%z}] [${BASH_SOURCE##*/}:${LINENO}] '
 
 set -x
 

--- a/scripts/mas.update.sh
+++ b/scripts/mas.update.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-export PS4=$'\n+CMD [\\D{%Y-%m-%dT%H:%M:%S%z}] [${BASH_SOURCE##*/}:${LINENO}] '
+export PS4=$'\n+CMD [\D{%Y-%m-%dT%H:%M:%S%z}] [${BASH_SOURCE##*/}:${LINENO}] '
 
 set -x
 

--- a/scripts/mas.update.sh
+++ b/scripts/mas.update.sh
@@ -6,8 +6,6 @@ export PS4=$'\n+CMD [\D{%Y-%m-%dT%H:%M:%S%z}] [${BASH_SOURCE##*/}:${LINENO}] '
 
 set -x
 
-date '+%Y-%m-%dT%H:%M:%S%z'
-
 mas list
 
 mas outdated

--- a/scripts/npm.global.update.sh
+++ b/scripts/npm.global.update.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-export PS4='+CMD [${BASH_SOURCE##*/}:${LINENO}] '
+export PS4=$'\n+CMD [\\D{%Y-%m-%dT%H:%M:%S%z}] [${BASH_SOURCE##*/}:${LINENO}] '
 
 set -x
 

--- a/scripts/npm.global.update.sh
+++ b/scripts/npm.global.update.sh
@@ -6,8 +6,6 @@ export PS4=$'\n+CMD [\D{%Y-%m-%dT%H:%M:%S%z}] [${BASH_SOURCE##*/}:${LINENO}] '
 
 set -x
 
-date '+%Y-%m-%dT%H:%M:%S%z'
-
 (
   cd "$HOME/repos"
 

--- a/scripts/npm.global.update.sh
+++ b/scripts/npm.global.update.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-export PS4=$'\n+CMD [\\D{%Y-%m-%dT%H:%M:%S%z}] [${BASH_SOURCE##*/}:${LINENO}] '
+export PS4=$'\n+CMD [\D{%Y-%m-%dT%H:%M:%S%z}] [${BASH_SOURCE##*/}:${LINENO}] '
 
 set -x
 

--- a/scripts/repo.sh
+++ b/scripts/repo.sh
@@ -2,7 +2,7 @@
 
 set -uo pipefail
 
-export PS4='+CMD [${BASH_SOURCE##*/}:${LINENO}] '
+export PS4=$'\n+CMD [\\D{%Y-%m-%dT%H:%M:%S%z}] [${BASH_SOURCE##*/}:${LINENO}] '
 
 set -x
 

--- a/scripts/repo.sh
+++ b/scripts/repo.sh
@@ -6,8 +6,6 @@ export PS4=$'\n+CMD [\D{%Y-%m-%dT%H:%M:%S%z}] [${BASH_SOURCE##*/}:${LINENO}] '
 
 set -x
 
-date '+%Y-%m-%dT%H:%M:%S%z'
-
 npx --yes envinfo@latest
 
 git status

--- a/scripts/repo.sh
+++ b/scripts/repo.sh
@@ -2,7 +2,7 @@
 
 set -uo pipefail
 
-export PS4=$'\n+CMD [\\D{%Y-%m-%dT%H:%M:%S%z}] [${BASH_SOURCE##*/}:${LINENO}] '
+export PS4=$'\n+CMD [\D{%Y-%m-%dT%H:%M:%S%z}] [${BASH_SOURCE##*/}:${LINENO}] '
 
 set -x
 

--- a/scripts/repos.update.sh
+++ b/scripts/repos.update.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-export PS4='+CMD [${BASH_SOURCE##*/}:${LINENO}] '
+export PS4=$'\n+CMD [\\D{%Y-%m-%dT%H:%M:%S%z}] [${BASH_SOURCE##*/}:${LINENO}] '
 
 set -x
 

--- a/scripts/repos.update.sh
+++ b/scripts/repos.update.sh
@@ -6,8 +6,6 @@ export PS4=$'\n+CMD [\D{%Y-%m-%dT%H:%M:%S%z}] [${BASH_SOURCE##*/}:${LINENO}] '
 
 set -x
 
-date '+%Y-%m-%dT%H:%M:%S%z'
-
 repo_root="$HOME/repos"
 
 repo_names=(

--- a/scripts/repos.update.sh
+++ b/scripts/repos.update.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-export PS4=$'\n+CMD [\\D{%Y-%m-%dT%H:%M:%S%z}] [${BASH_SOURCE##*/}:${LINENO}] '
+export PS4=$'\n+CMD [\D{%Y-%m-%dT%H:%M:%S%z}] [${BASH_SOURCE##*/}:${LINENO}] '
 
 set -x
 

--- a/scripts/system.sh
+++ b/scripts/system.sh
@@ -2,7 +2,7 @@
 
 set -uo pipefail
 
-export PS4='+CMD [${BASH_SOURCE##*/}:${LINENO}] '
+export PS4=$'\n+CMD [\\D{%Y-%m-%dT%H:%M:%S%z}] [${BASH_SOURCE##*/}:${LINENO}] '
 
 set -x
 

--- a/scripts/system.sh
+++ b/scripts/system.sh
@@ -6,8 +6,6 @@ export PS4=$'\n+CMD [\D{%Y-%m-%dT%H:%M:%S%z}] [${BASH_SOURCE##*/}:${LINENO}] '
 
 set -x
 
-date '+%Y-%m-%dT%H:%M:%S%z'
-
 sysctl -n hw.model
 uname -sr
 uname -m

--- a/scripts/system.sh
+++ b/scripts/system.sh
@@ -2,7 +2,7 @@
 
 set -uo pipefail
 
-export PS4=$'\n+CMD [\\D{%Y-%m-%dT%H:%M:%S%z}] [${BASH_SOURCE##*/}:${LINENO}] '
+export PS4=$'\n+CMD [\D{%Y-%m-%dT%H:%M:%S%z}] [${BASH_SOURCE##*/}:${LINENO}] '
 
 set -x
 

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-export PS4='+CMD [${BASH_SOURCE##*/}:${LINENO}] '
+export PS4=$'\n+CMD [\\D{%Y-%m-%dT%H:%M:%S%z}] [${BASH_SOURCE##*/}:${LINENO}] '
 
 set -x
 

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -6,8 +6,6 @@ export PS4=$'\n+CMD [\D{%Y-%m-%dT%H:%M:%S%z}] [${BASH_SOURCE##*/}:${LINENO}] '
 
 set -x
 
-date '+%Y-%m-%dT%H:%M:%S%z'
-
 script_dir=$(
   cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P
 )

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-export PS4=$'\n+CMD [\\D{%Y-%m-%dT%H:%M:%S%z}] [${BASH_SOURCE##*/}:${LINENO}] '
+export PS4=$'\n+CMD [\D{%Y-%m-%dT%H:%M:%S%z}] [${BASH_SOURCE##*/}:${LINENO}] '
 
 set -x
 


### PR DESCRIPTION
- Prepend PS4 traces with ISO-8601 timestamp using bash \D formatter
- Keep existing source file and line number context in logs

Signed-off-by: donniean <donniean1@gmail.com>