### PR TITLE
fix(cleanup): safely remove Codex archived sessions

### DIFF
--- a/scripts/cleanup/codex.sh
+++ b/scripts/cleanup/codex.sh
@@ -6,7 +6,7 @@ export PS4=$'\n+CMD [\D{%Y-%m-%dT%H:%M:%S%z}] [${BASH_SOURCE##*/}:${LINENO}] '
 
 set -x
 
-target_dir="${HOME}/.codex/archived_sessions/"
+target_dir="${HOME}/.codex/archived_sessions"
 
 if [[ ! -d "${target_dir}" ]]; then
   echo "Directory does not exist: ${target_dir}"

--- a/scripts/cleanup/codex.sh
+++ b/scripts/cleanup/codex.sh
@@ -2,4 +2,8 @@
 
 set -euo pipefail
 
+export PS4=$'\n+CMD [\D{%Y-%m-%dT%H:%M:%S%z}] [${BASH_SOURCE##*/}:${LINENO}] '
+
+set -x
+
 rm -rf "${HOME}/.codex/archived_sessions/"

--- a/scripts/cleanup/codex.sh
+++ b/scripts/cleanup/codex.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+rm -rf "${HOME}/.codex/archived_sessions/"

--- a/scripts/cleanup/codex.sh
+++ b/scripts/cleanup/codex.sh
@@ -6,4 +6,7 @@ export PS4=$'\n+CMD [\D{%Y-%m-%dT%H:%M:%S%z}] [${BASH_SOURCE##*/}:${LINENO}] '
 
 set -x
 
-rm -rf "${HOME}/.codex/archived_sessions/"
+TARGET_DIR="${HOME}/.codex/archived_sessions/"
+
+eza --tree --all --group-directories-first "${TARGET_DIR}"
+rm -rf "${TARGET_DIR}"

--- a/scripts/cleanup/codex.sh
+++ b/scripts/cleanup/codex.sh
@@ -6,7 +6,13 @@ export PS4=$'\n+CMD [\D{%Y-%m-%dT%H:%M:%S%z}] [${BASH_SOURCE##*/}:${LINENO}] '
 
 set -x
 
-TARGET_DIR="${HOME}/.codex/archived_sessions/"
+target_dir="${HOME}/.codex/archived_sessions/"
 
-eza --tree --all --group-directories-first "${TARGET_DIR}"
-rm -rf "${TARGET_DIR}"
+if [[ ! -d "${target_dir}" ]]; then
+  echo "Directory does not exist: ${target_dir}"
+  exit 0
+fi
+
+eza --tree --all --group-directories-first "${target_dir}"
+
+rm -rf "${target_dir}"


### PR DESCRIPTION
## Summary
- add a dedicated cleanup script for Codex archived sessions
- enable timestamped shell tracing for easier diagnostics
- list archived sessions before removal when available
- exit successfully when the archived sessions directory does not exist

## Testing
- run `bash scripts/cleanup/codex.sh` when `~/.codex/archived_sessions` is missing and confirm it exits successfully
- verify the script removes the directory when it exists