### PR TITLE
chore(scripts): relax nounset strictness for npm-global.sh

### DIFF
--- a/scripts/update/npm-global.sh
+++ b/scripts/update/npm-global.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -uo pipefail
 
 export PS4=$'\n+CMD [\D{%Y-%m-%dT%H:%M:%S%z}] [${BASH_SOURCE##*/}:${LINENO}] '
 


### PR DESCRIPTION
- remove -e option to avoid exiting on non-zero commands
- keep -u and pipefail to maintain safer error handling

Signed-off-by: donniean <donniean1@gmail.com>