### PR TITLE
chore(scripts/update): relax error handling in scripts

### DIFF
--- a/scripts/update/all.sh
+++ b/scripts/update/all.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -uo pipefail
 
 export PS4=$'\n+CMD [\D{%Y-%m-%dT%H:%M:%S%z}] [${BASH_SOURCE##*/}:${LINENO}] '
 

--- a/scripts/update/brew.sh
+++ b/scripts/update/brew.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -uo pipefail
 
 export PS4=$'\n+CMD [\D{%Y-%m-%dT%H:%M:%S%z}] [${BASH_SOURCE##*/}:${LINENO}] '
 

--- a/scripts/update/npm-global.sh
+++ b/scripts/update/npm-global.sh
@@ -7,7 +7,7 @@ export PS4=$'\n+CMD [\D{%Y-%m-%dT%H:%M:%S%z}] [${BASH_SOURCE##*/}:${LINENO}] '
 set -x
 
 (
-  cd "$HOME/repos"
+  cd "$HOME/repos" || exit
 
   fnm use default
 


### PR DESCRIPTION
- remove -e from bash strict mode to avoid immediate exit
- guard cd into $HOME/repos with fallback exit on failure

Co-authored-by: Copilot <copilot@github.com> Signed-off-by: donniean <donniean1@gmail.com>