### PR TITLE
ci(dependencies bump): gate auto-merge with input flag

### DIFF
--- a/.github/workflows/dependencies.bump.yaml
+++ b/.github/workflows/dependencies.bump.yaml
@@ -2,6 +2,11 @@ name: Dependencies Bump
 
 on:
   workflow_call:
+    inputs:
+      is-auto-merge:
+        required: false
+        type: boolean
+        default: true
     secrets:
       GPG_PRIVATE_KEY:
         required: true
@@ -72,7 +77,7 @@ jobs:
           title: ${{ env.COMMIT_MESSAGE }}
 
       - name: Auto-Merge Pull Request
-        if: ${{ steps.create-pull-request.outputs.pull-request-number }}
+        if: ${{ steps.create-pull-request.outputs.pull-request-number && inputs.is-auto-merge }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
- add workflow input is-auto-merge with default true
- only auto-merge pull requests when input is enabled

Signed-off-by: donniean <donniean1@gmail.com>