### PR TITLE
chore(ci): remove pnpm version pin and add packageManager

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,8 +15,6 @@ jobs:
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 11
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/dependencies.bump.yaml
+++ b/.github/workflows/dependencies.bump.yaml
@@ -31,8 +31,6 @@ jobs:
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 11
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "typescript-eslint": "8.59.1",
     "vitest": "4.1.5"
   },
+  "packageManager": "pnpm@11.0.1",
   "engines": {
     "node": ">=24.0.0",
     "pnpm": ">=11.0.0"


### PR DESCRIPTION
- rely on packageManager field for pnpm version
- remove redundant pnpm version setup in CI workflows

Signed-off-by: donniean <donniean1@gmail.com>