### PR TITLE
ci(workflows): use app tokens for PR automation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/dependencies.bump.yaml
+++ b/.github/workflows/dependencies.bump.yaml
@@ -70,7 +70,7 @@ jobs:
       - name: Auto-Merge Pull Request
         if: ${{ steps.create-pull-request.outputs.pull-request-number && inputs.is-auto-merge }}
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           url="${{ steps.create-pull-request.outputs.pull-request-url }}"
           # gh pr merge --disable-auto "$url" || true

--- a/.github/workflows/dependencies.bump.yaml
+++ b/.github/workflows/dependencies.bump.yaml
@@ -3,6 +3,9 @@ name: Dependencies Bump
 on:
   workflow_call:
     inputs:
+      app-client-id:
+        required: true
+        type: string
       is-auto-merge:
         required: false
         type: boolean
@@ -58,6 +61,12 @@ jobs:
           # cSpell: disable-next-line
           git_commit_gpgsign: true
 
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ inputs.app-client-id || vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: 'Create Pull Request'
         id: create-pull-request
         env:
@@ -65,13 +74,12 @@ jobs:
           COMMITTER: github-actions[bot] <12584040+donniean@users.noreply.github.com>
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: ${{ env.COMMIT_MESSAGE }}
-          committer: ${{ env.COMMITTER}}
-          author: ${{ env.COMMITTER}}
           signoff: true
           delete-branch: true
           branch-suffix: timestamp
+          sign-commits: true
           title: ${{ env.COMMIT_MESSAGE }}
 
       - name: Auto-Merge Pull Request

--- a/.github/workflows/dependencies.bump.yaml
+++ b/.github/workflows/dependencies.bump.yaml
@@ -11,11 +11,7 @@ on:
         type: boolean
         default: true
     secrets:
-      GPG_PRIVATE_KEY:
-        required: true
-      GPG_PASSPHRASE:
-        required: true
-      GH_TOKEN:
+      APP_PRIVATE_KEY:
         required: true
   schedule:
     - cron: '0 0 * * *'
@@ -50,17 +46,6 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --no-frozen-lockfile
 
-      - name: Import GPG Key
-        # cSpell: disable-next-line
-        uses: crazy-max/ghaction-import-gpg@v7
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
-          # cSpell: disable-next-line
-          git_user_signingkey: true
-          # cSpell: disable-next-line
-          git_commit_gpgsign: true
-
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
@@ -71,7 +56,6 @@ jobs:
         id: create-pull-request
         env:
           COMMIT_MESSAGE: 'chore(bot): bump dependencies'
-          COMMITTER: github-actions[bot] <12584040+donniean@users.noreply.github.com>
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/dependencies.bump.yaml
+++ b/.github/workflows/dependencies.bump.yaml
@@ -18,8 +18,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   bump:
@@ -51,6 +50,8 @@ jobs:
         with:
           client-id: ${{ inputs.app-client-id || vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: 'Create Pull Request'
         id: create-pull-request
@@ -69,7 +70,7 @@ jobs:
       - name: Auto-Merge Pull Request
         if: ${{ steps.create-pull-request.outputs.pull-request-number && inputs.is-auto-merge }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           url="${{ steps.create-pull-request.outputs.pull-request-url }}"
           # gh pr merge --disable-auto "$url" || true

--- a/.github/workflows/dependencies.bump.yaml
+++ b/.github/workflows/dependencies.bump.yaml
@@ -4,6 +4,7 @@ on:
   workflow_call:
     inputs:
       app-client-id:
+        description: GitHub App client ID for reusable workflow callers. Direct runs use vars.APP_CLIENT_ID.
         required: true
         type: string
       is-auto-merge:
@@ -48,6 +49,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
+          # Reusable callers pass this input; direct runs use this repository variable.
           client-id: ${{ inputs.app-client-id || vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           permission-contents: write

--- a/.github/workflows/pull-requests.auto-merge.yaml
+++ b/.github/workflows/pull-requests.auto-merge.yaml
@@ -14,10 +14,13 @@ jobs:
       # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request
       - name: Auto-Merge Dependabot Pull Requests
         if: >
-          github.actor == env.DEPENDABOT_USERNAME ||
-          github.event.pull_request.user.login == env.DEPENDABOT_USERNAME
+          github.event.pull_request.html_url &&
+          (
+            github.actor == env.DEPENDABOT_USERNAME ||
+            github.event.pull_request.user.login == env.DEPENDABOT_USERNAME
+          )
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           DEPENDABOT_USERNAME: dependabot[bot]
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull-requests.auto-update.yaml
+++ b/.github/workflows/pull-requests.auto-update.yaml
@@ -19,6 +19,8 @@ jobs:
         with:
           client-id: ${{ inputs.app-client-id || vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       # cSpell:disable-next-line
       - uses: docker://chinthakagodawita/autoupdate-action:v1

--- a/.github/workflows/pull-requests.auto-update.yaml
+++ b/.github/workflows/pull-requests.auto-update.yaml
@@ -26,7 +26,7 @@ jobs:
           permission-contents: write
           permission-pull-requests: write
 
-      # cSpell:disable-next-line
+      # cSpell: disable-next-line
       - uses: docker://chinthakagodawita/autoupdate-action:v1
         env:
           GITHUB_TOKEN: '${{ steps.app-token.outputs.token }}'

--- a/.github/workflows/pull-requests.auto-update.yaml
+++ b/.github/workflows/pull-requests.auto-update.yaml
@@ -1,6 +1,10 @@
 name: Pull Requests Auto-Update
 on:
   workflow_call:
+    inputs:
+      app-client-id:
+        required: true
+        type: string
     secrets:
       APP_PRIVATE_KEY:
         required: true
@@ -13,7 +17,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          client-id: ${{ vars.APP_CLIENT_ID }}
+          client-id: ${{ inputs.app-client-id || vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       # cSpell:disable-next-line

--- a/.github/workflows/pull-requests.auto-update.yaml
+++ b/.github/workflows/pull-requests.auto-update.yaml
@@ -3,6 +3,7 @@ on:
   workflow_call:
     inputs:
       app-client-id:
+        description: GitHub App client ID for reusable workflow callers. Direct runs use vars.APP_CLIENT_ID.
         required: true
         type: string
     secrets:
@@ -17,6 +18,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
+          # Reusable callers pass this input; direct runs use this repository variable.
           client-id: ${{ inputs.app-client-id || vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           permission-contents: write

--- a/.github/workflows/pull-requests.auto-update.yaml
+++ b/.github/workflows/pull-requests.auto-update.yaml
@@ -11,6 +11,8 @@ on:
         required: true
   push:
 
+permissions: {}
+
 jobs:
   auto-update:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-requests.auto-update.yaml
+++ b/.github/workflows/pull-requests.auto-update.yaml
@@ -26,7 +26,12 @@ jobs:
           permission-contents: write
           permission-pull-requests: write
 
-      # cSpell: disable-next-line
-      - uses: docker://chinthakagodawita/autoupdate-action:v1
-        env:
-          GITHUB_TOKEN: '${{ steps.app-token.outputs.token }}'
+      - name: Automatically Update Pull Request
+        uses: adRise/update-pr-branch@v0.11
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          base: ${{ github.ref_name }}
+          required_approval_count: 0
+          require_passed_checks: true
+          allow_ongoing_checks: true
+          require_auto_merge_enabled: true

--- a/.github/workflows/pull-requests.auto-update.yaml
+++ b/.github/workflows/pull-requests.auto-update.yaml
@@ -12,14 +12,13 @@ jobs:
   auto-update:
     runs-on: ubuntu-latest
     steps:
-      - name: Generate a Token
-        id: generate-token
-        uses: actions/create-github-app-token@v3
+      - uses: actions/create-github-app-token@v3
+        id: app-token
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       # cSpell:disable-next-line
       - uses: docker://chinthakagodawita/autoupdate-action:v1
         env:
-          GITHUB_TOKEN: '${{ steps.generate-token.outputs.token }}'
+          GITHUB_TOKEN: '${{ steps.app-token.outputs.token }}'

--- a/.github/workflows/pull-requests.auto-update.yaml
+++ b/.github/workflows/pull-requests.auto-update.yaml
@@ -2,8 +2,6 @@ name: Pull Requests Auto-Update
 on:
   workflow_call:
     secrets:
-      APP_ID:
-        required: true
       APP_PRIVATE_KEY:
         required: true
   push:


### PR DESCRIPTION
## Background

This PR addresses the workflow automation problems tracked in #535, #536, #1098, and #550.

#535 documents the token identity tradeoff in the dependency bump and pull request automation workflows:

- using `GITHUB_TOKEN` keeps automation under a bot identity, but events created with that token do not reliably trigger follow-up workflows and required checks;
- using a PAT allows follow-up checks to run, but the resulting commits are attributed to a personal user;
- the intended outcome is automated PR activity that can trigger checks while avoiding personal-user authorship.

#536 documents the related signed-commit problem:

- GitHub Actions generated dependency bump commits were not verified;
- enabling `Require signed commits` in rulesets forced that requirement to be disabled for automation to merge;
- the intended outcome is automated dependency bump commits that can satisfy signed-commit enforcement.

#1098 tracks the workflow permission hardening work:

- CodeQL reported missing explicit workflow permissions for GitHub Actions workflows;
- workflows should avoid relying on default `GITHUB_TOKEN` permissions;
- write permissions should be granted only where the workflow actually needs them.

#550 tracks refactoring the pull request auto-update workflow:

- the old workflow used the Docker-based `chinthakagodawita/autoupdate-action`;
- the repository now needs a narrower auto-update path that works with `Require branches to be up to date before merging` and GitHub auto-merge;
- the replacement should continue to use the GitHub App token rather than `GITHUB_TOKEN` or a PAT.

## What Changed

- Replaced the PAT/GPG dependency bump path with a GitHub App installation token generated by `actions/create-github-app-token`.
- Added `sign-commits: true` to `peter-evans/create-pull-request` so dependency bump commits are signed by the GitHub bot token flow.
- Added an explicit `app-client-id` reusable workflow input while keeping `vars.APP_CLIENT_ID` as the direct-run fallback for this repository.
- Restricted default workflow `GITHUB_TOKEN` permissions:
  - `ci.yaml` now uses `contents: read`.
  - `dependencies.bump.yaml` now uses `contents: read` and obtains write permissions only through the GitHub App token step.
  - `pull-requests.auto-update.yaml` now uses `permissions: {}` because it does not need the default `GITHUB_TOKEN`.
- Updated pull request branch auto-update automation to use `adRise/update-pr-branch@v0.11` with the GitHub App token instead of the older Docker-based `chinthakagodawita/autoupdate-action`.
- Tightened the Dependabot auto-merge condition so reusable workflow executions without a `pull_request` payload do not evaluate pull request fields blindly.

## Why This Approach

A GitHub App installation token fits the automation requirements better than both previous options:

- unlike `GITHUB_TOKEN`, it can trigger follow-up workflows and required checks when it updates branches or creates commits;
- unlike a PAT, it keeps automation under an app/bot identity instead of a personal user;
- it can be scoped to the workflow's real needs with `contents: write` and `pull-requests: write` only in the token-generation step.

For dependency bumps, `peter-evans/create-pull-request` supports bot-token commit signing through `sign-commits: true`, which directly addresses the signed-commit requirement from #536 without importing and managing a separate GPG key in Actions.

For PR branch updates, `adRise/update-pr-branch` is a better fit for this repository than the previous generic auto-update action because it is specifically designed for repositories using GitHub auto-merge together with `Require branches to be up to date before merging`. The workflow config keeps the scope narrow by requiring auto-merge to be enabled on a PR before updating it.

## Workflow Contract

Reusable workflow callers must now pass `app-client-id` and `APP_PRIVATE_KEY` when using these workflows through `workflow_call`.

Direct runs in this repository use `vars.APP_CLIENT_ID` together with `secrets.APP_PRIVATE_KEY`. The inline comments in the workflows document that split explicitly.

## Validation

Validated locally with:

- `pnpm run lint:format`
- `pnpm run lint:spell`
- `pnpm run lint:text`
- `git diff --check`
- `yq` parsing checks for the edited workflow files
- `bash -n` on the intermediate shell implementation before replacing it with `adRise/update-pr-branch`

GitHub Actions must still run after this PR is opened to verify the GitHub App token permissions and the end-to-end branch update behavior in the remote environment.

## Issues

Closes #535.
Closes #536.
Closes #1098.
Closes #550.