### PR TITLE
ci(workflows): refactor dependency automation scripts

### DIFF
--- a/.github/workflows/dependencies.bump.yaml
+++ b/.github/workflows/dependencies.bump.yaml
@@ -73,7 +73,6 @@ jobs:
         if: ${{ steps.create-pull-request.outputs.pull-request-number && inputs.is-auto-merge }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_URL: ${{ steps.create-pull-request.outputs.pull-request-url }}
         run: |
-          url="${{ steps.create-pull-request.outputs.pull-request-url }}"
-          # gh pr merge --disable-auto "$url" || true
-          gh pr merge --auto --squash "$url"
+          gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/pull-requests.auto-merge.yaml
+++ b/.github/workflows/pull-requests.auto-merge.yaml
@@ -11,7 +11,7 @@ jobs:
   auto-merge:
     runs-on: ubuntu-latest
     steps:
-      # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request
+      # https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/automate-dependabot-with-actions#enabling-automerge-on-a-pull-request
       - name: Auto-Merge Dependabot Pull Requests
         if: >
           github.event.pull_request.html_url &&


### PR DESCRIPTION
## Summary
- Keep the dependency bump auto-merge command using an environment-provided PR URL instead of an inline shell assignment.
- Remove the stale disabled merge command from the dependency bump workflow.
- Update the Dependabot auto-merge GitHub Docs link to the current documentation URL.

## Validation
- `yq --exit-status '.' .github/workflows/*.yaml .github/dependabot.yaml >/dev/null`
- `fnm exec --using-file -- pnpm run lint:format`
- `fnm exec --using-file -- pnpm run lint:md`
- `actionlint -color=false` fails on existing `actions/create-github-app-token@v3` metadata validation for `client-id` in `.github/workflows/dependencies.bump.yaml` and `.github/workflows/pull-requests.auto-update.yaml`; this PR does not change that usage.