### PR TITLE
fix(workflows): allow dependency auto-merge

### DIFF
--- a/.github/workflows/dependencies.bump.yaml
+++ b/.github/workflows/dependencies.bump.yaml
@@ -70,7 +70,9 @@ jobs:
           title: ${{ env.COMMIT_MESSAGE }}
 
       - name: Auto-Merge Pull Request
-        if: ${{ steps.create-pull-request.outputs.pull-request-number && inputs.is-auto-merge }}
+        if: >
+          steps.create-pull-request.outputs.pull-request-number &&
+          toJSON(inputs.is-auto-merge) != 'false'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_URL: ${{ steps.create-pull-request.outputs.pull-request-url }}


### PR DESCRIPTION
## Summary

- Update the dependency bump workflow auto-merge condition so direct runs default to enabling auto-merge.
- Preserve the `workflow_call` opt-out behavior when callers explicitly pass `is-auto-merge: false`.

## Context

The workflow previously checked `inputs.is-auto-merge` directly. For scheduled or manually triggered direct runs, that input is not supplied through `workflow_call`, so the auto-merge step could be skipped even though the workflow default is intended to allow it.

Using `toJSON(inputs.is-auto-merge) != 'false'` only disables auto-merge for an explicit boolean `false` value.

## Validation

- `yq '.jobs.bump.steps[] | select(.name == "Auto-Merge Pull Request") | .if' .github/workflows/dependencies.bump.yaml`
- `git diff --check`
- `pnpm run lint:format`
- `pnpm run lint:spell`
- `pnpm run lint:text`
- Commit hooks: `prettier`, `autocorrect`, `cspell`