### PR TITLE
fix: skip Homebrew upgrade prompts

### DIFF
--- a/scripts/update/brew.sh
+++ b/scripts/update/brew.sh
@@ -17,8 +17,8 @@ brew outdated --cask --greedy --verbose
 brew upgrade --formula --display-times --dry-run
 brew upgrade --cask --greedy --display-times --dry-run
 
-brew upgrade --formula --display-times
-brew upgrade --cask --greedy --display-times
+brew upgrade --formula --display-times --yes
+brew upgrade --cask --greedy --display-times --yes
 
 brew autoremove
 brew cleanup


### PR DESCRIPTION
## Summary

- Add `--yes` to the Homebrew formula and cask upgrade commands in `scripts/update/brew.sh`.
- Keep the existing dry-run commands interactive-free without adding unnecessary flags.

## Why

Homebrew now uses ask mode by default for `brew upgrade`, which can pause this update script for confirmation in an interactive terminal. The script already prints dry-run output before applying upgrades, so the actual upgrade steps should proceed without a second manual confirmation.

## Validation

- `bash -n scripts/update/brew.sh`
- `git diff --check -- scripts/update/brew.sh`
- commit hook: `prettier --write --ignore-unknown`
- commit hook: `autocorrect --fix`
- commit hook: `cspell lint --no-progress --no-must-find-files --dot --gitignore`

The update script itself was not run because it updates local Homebrew packages and cleanup state.