### PR TITLE
ci(deps): install before dependency bumps

### DIFF
--- a/.github/workflows/dependencies.bump.yaml
+++ b/.github/workflows/dependencies.bump.yaml
@@ -37,13 +37,16 @@ jobs:
           node-version-file: .nvmrc
           cache: pnpm
 
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Bump Dependencies
         run: pnpm run ncu:upgrade
 
       - name: Remove Dependencies
         run: pnpm dlx rimraf@latest --glob "**/node_modules/" "**/pnpm-lock.yaml"
 
-      - name: Install Dependencies
+      - name: Update Lockfile
         run: pnpm install --no-frozen-lockfile
 
       - uses: actions/create-github-app-token@v3

--- a/.github/workflows/dependencies.bump.yaml
+++ b/.github/workflows/dependencies.bump.yaml
@@ -38,7 +38,7 @@ jobs:
           cache: pnpm
 
       - name: Install Dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
 
       - name: Bump Dependencies
         run: pnpm run ncu:upgrade
@@ -46,7 +46,7 @@ jobs:
       - name: Remove Dependencies
         run: pnpm dlx rimraf@latest --glob "**/node_modules/" "**/pnpm-lock.yaml"
 
-      - name: Update Lockfile
+      - name: Install Updated Dependencies
         run: pnpm install --no-frozen-lockfile
 
       - uses: actions/create-github-app-token@v3


### PR DESCRIPTION
## Summary

- Install project dependencies before running `pnpm run ncu:upgrade` in the reusable dependency bump workflow.
- Rename the later install step to clarify that it regenerates dependencies after package updates.

## Validation

- `git diff --check`
- `pnpm run lint` was attempted. It fails on existing `snippets/**` ESLint issues unrelated to this workflow change; the other lint subtasks completed successfully before `lint:js` failed.