### PR TITLE
fix: skip Homebrew dry-run prompts

### DIFF
--- a/scripts/update/brew.sh
+++ b/scripts/update/brew.sh
@@ -14,8 +14,8 @@ brew update
 brew outdated --formula --verbose
 brew outdated --cask --greedy --verbose
 
-brew upgrade --formula --display-times --dry-run --yes
-brew upgrade --cask --greedy --display-times --dry-run --yes
+brew upgrade --formula --display-times --yes --dry-run
+brew upgrade --cask --greedy --display-times --yes --dry-run
 
 brew upgrade --formula --display-times --yes
 brew upgrade --cask --greedy --display-times --yes

--- a/scripts/update/brew.sh
+++ b/scripts/update/brew.sh
@@ -14,8 +14,8 @@ brew update
 brew outdated --formula --verbose
 brew outdated --cask --greedy --verbose
 
-brew upgrade --formula --display-times --dry-run
-brew upgrade --cask --greedy --display-times --dry-run
+brew upgrade --formula --display-times --dry-run --yes
+brew upgrade --cask --greedy --display-times --dry-run --yes
 
 brew upgrade --formula --display-times --yes
 brew upgrade --cask --greedy --display-times --yes


### PR DESCRIPTION
## Summary

- Add `--yes` to the Homebrew formula and cask dry-run upgrade commands.
- Keep dry-run behavior aligned with the real upgrade commands that already skip prompts.

## Validation

- `bash -n scripts/update/brew.sh`
- `git diff --check -- scripts/update/brew.sh`

## Notes

- `scripts/update/brew.sh` was not executed because it mutates local Homebrew state.