### PR TITLE
chore(tooling): sync npm script conventions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,29 +32,29 @@ jobs:
       #   run: pnpm run lint
       # Linters
 
-      - name: lint:package-json
-        run: pnpm run lint:package-json
+      - name: format:package-json:check
+        run: pnpm run format:package-json:check
 
-      - name: lint:format
-        run: pnpm run lint:format
+      - name: format:prettier:check
+        run: pnpm run format:prettier:check
 
-      # - name: lint:types
-      #   run: pnpm run lint:types
+      # - name: typecheck
+      #   run: pnpm run typecheck
 
-      # - name: lint:js
-      #   run: pnpm run lint:js
+      # - name: lint:eslint
+      #   run: pnpm run lint:eslint
 
-      - name: lint:css
-        run: pnpm run lint:css
+      - name: lint:styles
+        run: pnpm run lint:styles
 
       - name: lint:html
         run: pnpm run lint:html
 
-      - name: lint:md
-        run: pnpm run lint:md
+      - name: lint:markdown
+        run: pnpm run lint:markdown
 
-      - name: lint:text
-        run: pnpm run lint:text
+      - name: lint:autocorrect
+        run: pnpm run lint:autocorrect
 
-      - name: lint:spell
-        run: pnpm run lint:spell
+      - name: lint:spellcheck
+        run: pnpm run lint:spellcheck

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,39 +46,41 @@ Scripts under [`scripts/inspect/`](scripts/inspect/) are intended for read-only 
 Run checks relevant to the change scope:
 
 ```bash
-pnpm run lint:md
-pnpm run lint:format
-pnpm run lint:spell
-pnpm run lint:text
+pnpm run lint:markdown
+pnpm run format:prettier:check
+pnpm run lint:spellcheck
+pnpm run lint:autocorrect
 pnpm run test
 pnpm run test:unit
 ```
 
-`pnpm run lint` includes `lint:js`. `lint:js` is not part of the current default validation for legacy snippets; the long-term target is to fix those snippets or migrate them to TypeScript so they meet the JavaScript linting standard.
+`pnpm run lint` includes `lint:eslint`. `lint:eslint` is not part of the current CI default validation for legacy snippets; the long-term target is to fix those snippets or migrate them to TypeScript so they meet the JavaScript linting standard.
 
 If check results can be fixed automatically, prefer the smallest relevant `fix` command instead of running a full-repository fix indiscriminately.
 
 Use smaller checks by file type when possible:
 
 ```bash
-pnpm run lint:md
-pnpm run lint:js
-pnpm run lint:types
-pnpm run lint:css
+pnpm run format:package-json:check
+pnpm run format:prettier:check
+pnpm run lint:autocorrect
+pnpm run lint:eslint
 pnpm run lint:html
-pnpm run lint:format
-pnpm run lint:spell
-pnpm run lint:text
-pnpm run lint:package-json
+pnpm run lint:knip
+pnpm run lint:markdown
+pnpm run lint:spellcheck
+pnpm run lint:styles
+pnpm run typecheck
 ```
 
 Matching `fix` commands include:
 
-- `pnpm run lint:md:fix`
-- `pnpm run lint:js:fix`
-- `pnpm run lint:css:fix`
-- `pnpm run lint:format:fix`
-- `pnpm run lint:text:fix`
-- `pnpm run lint:package-json:fix`
+- `pnpm run format:package-json`
+- `pnpm run format:prettier`
+- `pnpm run lint:autocorrect:fix`
+- `pnpm run lint:eslint:fix`
+- `pnpm run lint:knip:fix`
+- `pnpm run lint:markdown:fix`
+- `pnpm run lint:styles:fix`
 
-CI currently runs only `lint:package-json`, `lint:format`, `lint:css`, `lint:html`, `lint:md`, `lint:text`, and `lint:spell`. `lint:types`, `lint:js`, `pnpm run test`, `pnpm run test:unit`, and local maintenance scripts are not covered by the current CI; validate related changes locally.
+CI currently runs only `format:package-json:check`, `format:prettier:check`, `lint:styles`, `lint:html`, `lint:markdown`, `lint:autocorrect`, and `lint:spellcheck`. `typecheck`, `lint:eslint`, `pnpm run test`, `pnpm run test:unit`, and local maintenance scripts are not covered by the current CI; validate related changes locally.

--- a/README.md
+++ b/README.md
@@ -18,17 +18,16 @@ Output from inspection scripts may include local environment details, account st
 ## Requirements
 
 - The Node.js version is defined by [`.nvmrc`](.nvmrc) and `engines.node` in [`package.json`](package.json). See [Node.js version upgrade](docs/node-version-upgrade.md).
-- The pnpm version is defined by `packageManager` and `engines.pnpm` in [`package.json`](package.json).
-- Use `pnpm`. `preinstall` enforces this with `only-allow`.
+- The required pnpm version is pinned by the `packageManager` in [`package.json`](package.json).
 
 ## Commands
 
 ```bash
 pnpm install
-pnpm run lint:md
-pnpm run lint:format
-pnpm run lint:spell
-pnpm run lint:text
+pnpm run lint:markdown
+pnpm run format:prettier:check
+pnpm run lint:spellcheck
+pnpm run lint:autocorrect
 pnpm run test
 pnpm run test:unit
 pnpm run test:unit:coverage
@@ -37,7 +36,7 @@ pnpm run test:unit:ui
 pnpm run serve
 ```
 
-`pnpm run lint` includes `lint:js`. `lint:js` is not part of the current default validation for legacy snippets; the long-term target is to fix those snippets or migrate them to TypeScript so they meet the JavaScript linting standard.
+`pnpm run lint` includes `lint:eslint`. `lint:eslint` is not part of the current CI default validation for legacy snippets; the long-term target is to fix those snippets or migrate them to TypeScript so they meet the JavaScript linting standard.
 
 `pnpm run serve` starts a static server for [`apps/playground/`](apps/playground/).
 

--- a/package.json
+++ b/package.json
@@ -14,26 +14,25 @@
   "author": "Donnie An",
   "type": "module",
   "scripts": {
-    "preinstall": "pnpm dlx only-allow@latest pnpm",
-    "knip": "knip",
-    "knip:fix": "pnpm run knip --fix",
-    "lint": "concurrently --group --timings \"pnpm:lint:*(!:fix)\"",
-    "lint:css": "stylelint \"**/*.css\"",
-    "lint:css:fix": "pnpm run lint:css --fix",
-    "lint:fix": "concurrently --max-processes=1 --group --timings \"pnpm:lint:*:fix\"",
-    "lint:format": "prettier --check --ignore-unknown .",
-    "lint:format:fix": "prettier --write --ignore-unknown .",
+    "format:package-json": "sort-package-json \"**/package.json\" --ignore \"**/node_modules/**/package.json\" --ignore \"**/dist/**/package.json\"",
+    "format:package-json:check": "pnpm run format:package-json --check",
+    "format:prettier": "prettier --write --ignore-unknown .",
+    "format:prettier:check": "prettier --check --ignore-unknown .",
+    "preinstall": "npx only-allow@latest pnpm",
+    "lint": "concurrently --group --timings \"pnpm:lint:*(!:fix|^lint:knip$)\" \"pnpm:format:*:check\" \"pnpm:typecheck\"",
+    "lint:autocorrect": "autocorrect --lint",
+    "lint:autocorrect:fix": "autocorrect --fix",
+    "lint:eslint": "eslint",
+    "lint:eslint:fix": "eslint --fix",
+    "lint:fix": "concurrently --max-processes=1 --group --timings \"pnpm:lint:*:fix(!^lint:knip:fix$)\" \"pnpm:format:*(!:check)\"",
     "lint:html": "html-validate \"**/*.html\"",
-    "lint:js": "eslint",
-    "lint:js:fix": "pnpm run lint:js --fix",
-    "lint:md": "markdownlint --dot \"**/*.md\"",
-    "lint:md:fix": "pnpm run lint:md --fix",
-    "lint:package-json": "pnpm run lint:package-json:fix --check",
-    "lint:package-json:fix": "sort-package-json \"**/package.json\" --ignore \"**/node_modules/**/package.json\" --ignore \"**/dist/**/package.json\"",
-    "lint:spell": "cspell lint --no-progress --no-must-find-files --dot --gitignore .",
-    "lint:text": "autocorrect --lint",
-    "lint:text:fix": "autocorrect --fix",
-    "lint:types": "tsc --noEmit",
+    "lint:knip": "knip",
+    "lint:knip:fix": "knip --fix",
+    "lint:markdown": "markdownlint --dot \"**/*.md\"",
+    "lint:markdown:fix": "pnpm run lint:markdown --fix",
+    "lint:spellcheck": "cspell lint --no-progress --no-must-find-files --dot --gitignore .",
+    "lint:styles": "stylelint \"**/*.css\"",
+    "lint:styles:fix": "pnpm run lint:styles --fix",
     "ncu": "ncu --deep --format cooldown",
     "ncu:upgrade": "pnpm run ncu --upgrade",
     "prepare": "husky",
@@ -42,7 +41,8 @@
     "test:unit": "vitest run --pass-with-no-tests",
     "test:unit:coverage": "vitest run --coverage",
     "test:unit:ui": "vitest --ui",
-    "test:unit:watch": "vitest watch"
+    "test:unit:watch": "vitest watch",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@commitlint/cli": "21.0.2",
@@ -87,7 +87,6 @@
   },
   "packageManager": "pnpm@11.6.0",
   "engines": {
-    "node": ">=24.0.0 <25.0.0",
-    "pnpm": ">=11.0.0"
+    "node": ">=24.0.0 <25.0.0"
   }
 }


### PR DESCRIPTION
## Summary

- Sync npm script naming with donniean/react-app#2395.
- Add dedicated format scripts and keep pnpm enforcement through packageManager plus the only-allow preinstall guard.
- Update README, AGENTS, and CI script references while preserving the existing CI validation scope.

## Validation

- fnm exec --using 24 pnpm exec concurrently --group --timings "pnpm:format:*:check" "pnpm:lint:styles" "pnpm:lint:html" "pnpm:lint:markdown" "pnpm:lint:autocorrect" "pnpm:lint:spellcheck"
- fnm exec --using 24 pnpm run test
- git diff --check
