### PR TITLE
chore(tooling): remove pnpm install guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "format:package-json:check": "pnpm run format:package-json --check",
     "format:prettier": "prettier --write --ignore-unknown .",
     "format:prettier:check": "prettier --check --ignore-unknown .",
-    "preinstall": "npx only-allow@latest pnpm",
     "lint": "concurrently --group --timings \"pnpm:lint:*(!:fix|^lint:knip$)\" \"pnpm:format:*:check\" \"pnpm:typecheck\"",
     "lint:autocorrect": "autocorrect --lint",
     "lint:autocorrect:fix": "autocorrect --fix",


### PR DESCRIPTION
## Summary

- Remove the deprecated `only-allow` preinstall guard.
- Keep `packageManager` as the pnpm version source of truth.
- Rely on the pnpm lockfile and CI pnpm setup for package-manager consistency.

## Validation

- `pnpm run format:package-json:check`
