### PR TITLE
chore(cspell): normalize dictionary casing

### DIFF
--- a/cspell.config.mjs
+++ b/cspell.config.mjs
@@ -9,9 +9,9 @@ export default defineConfig({
     'webstorm',
     'wechat',
     // brands
-    'Vercel',
+    'vercel',
     // Docker
-    'Buildx',
+    'buildx',
     // files
     '.autocorrectignore',
     '.autocorrectrc',
@@ -57,7 +57,7 @@ export default defineConfig({
     'nodenext',
     'classname',
     // Vite
-    'VITE',
+    'vite',
     // custom
     'donniean',
   ],


### PR DESCRIPTION
## Summary

- Normalize cspell dictionary entries for Vite, Vercel, and Buildx to lowercase.
- Keep dictionary casing consistent with project tooling names.

## Verification

- `pnpm exec cspell lint --no-progress --no-must-find-files --dot --gitignore --exclude .git .`