### PR TITLE
build: add oxlint tsgolint dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "markdownlint-cli": "0.48.0",
     "npm-check-updates": "22.2.3",
     "oxlint": "1.70.0",
+    "oxlint-tsgolint": "0.23.0",
     "prettier": "3.8.4",
     "serve": "14.2.6",
     "sort-package-json": "4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       oxlint:
         specifier: 1.70.0
         version: 1.70.0(oxlint-tsgolint@0.23.0)
+      oxlint-tsgolint:
+        specifier: 0.23.0
+        version: 0.23.0
       prettier:
         specifier: 3.8.4
         version: 3.8.4
@@ -4676,7 +4679,6 @@ snapshots:
       '@oxlint-tsgolint/linux-x64': 0.23.0
       '@oxlint-tsgolint/win32-arm64': 0.23.0
       '@oxlint-tsgolint/win32-x64': 0.23.0
-    optional: true
 
   oxlint@1.70.0(oxlint-tsgolint@0.23.0):
     optionalDependencies:


### PR DESCRIPTION
## Summary

- Add `oxlint-tsgolint` as a dev dependency.
- Update `pnpm-lock.yaml` through `pnpm add --save-dev oxlint-tsgolint`.

## Validation

- `pnpm run format:package-json:check` passed.
- `pnpm run format:prettier:check package.json pnpm-lock.yaml` passed.
- `pnpm run lint:oxlint` was run and failed on existing legacy snippet/type-aware lint findings unrelated to this dependency-only change. This matches the repository documentation noting `lint:oxlint` is not part of current default validation for legacy snippets.

## Notes

- Dependency resolved to `oxlint-tsgolint@0.23.0`.