### PR TITLE
chore(format): migrate from Prettier to Oxfmt

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -114,7 +114,6 @@ TODO text
 package.json text eol=lf
 package-lock.json text eol=lf -diff
 pnpm-lock.yaml text eol=lf -diff
-.prettierrc text
 yarn.lock text -diff
 *.toml text
 *.yaml text

--- a/.gitattributes
+++ b/.gitattributes
@@ -114,6 +114,7 @@ TODO text
 package.json text eol=lf
 package-lock.json text eol=lf -diff
 pnpm-lock.yaml text eol=lf -diff
+.prettierrc text
 yarn.lock text -diff
 *.toml text
 *.yaml text

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,11 +32,8 @@ jobs:
       #   run: pnpm run lint
       # Linters
 
-      - name: format:package-json:check
-        run: pnpm run format:package-json:check
-
-      - name: format:prettier:check
-        run: pnpm run format:prettier:check
+      - name: format:oxfmt:check
+        run: pnpm run format:oxfmt:check
 
       # - name: typecheck
       #   run: pnpm run typecheck

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,0 @@
-**/package-lock.json
-**/pnpm-lock.yaml
-**/yarn.lock
-**/*.min.*

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["oxc.oxc-vscode"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,9 @@
 {
+  "editor.codeActionsOnSave": {
+    "source.fixAll.oxc": "explicit"
+  },
+  "editor.defaultFormatter": "oxc.oxc-vscode",
+  "editor.formatOnSave": true,
   "js/ts.tsdk.path": "node_modules/typescript/lib",
   "js/ts.tsdk.promptToUseWorkspaceVersion": true
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ Run checks relevant to the change scope:
 
 ```bash
 pnpm run lint:markdown
-pnpm run format:prettier:check
+pnpm run format:oxfmt:check
 pnpm run lint:spellcheck
 pnpm run lint:autocorrect
 pnpm run test
@@ -61,8 +61,7 @@ If check results can be fixed automatically, prefer the smallest relevant `fix` 
 Use smaller checks by file type when possible:
 
 ```bash
-pnpm run format:package-json:check
-pnpm run format:prettier:check
+pnpm run format:oxfmt:check
 pnpm run lint:autocorrect
 pnpm run lint:oxlint
 pnpm run lint:html
@@ -74,11 +73,10 @@ pnpm run typecheck
 
 Matching `fix` commands include:
 
-- `pnpm run format:package-json`
-- `pnpm run format:prettier`
+- `pnpm run format:oxfmt`
 - `pnpm run lint:autocorrect:fix`
 - `pnpm run lint:oxlint:fix`
 - `pnpm run lint:markdown:fix`
 - `pnpm run lint:styles:fix`
 
-CI currently runs only `format:package-json:check`, `format:prettier:check`, `lint:styles`, `lint:html`, `lint:markdown`, `lint:autocorrect`, and `lint:spellcheck`. `typecheck`, `lint:oxlint`, `pnpm run test`, `pnpm run test:unit`, and local maintenance scripts are not covered by the current CI; validate related changes locally.
+CI currently runs only `format:oxfmt:check`, `lint:styles`, `lint:html`, `lint:markdown`, `lint:autocorrect`, and `lint:spellcheck`. `typecheck`, `lint:oxlint`, `pnpm run test`, `pnpm run test:unit`, and local maintenance scripts are not covered by the current CI; validate related changes locally.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Output from inspection scripts may include local environment details, account st
 ```bash
 pnpm install
 pnpm run lint:markdown
-pnpm run format:prettier:check
+pnpm run format:oxfmt:check
 pnpm run lint:spellcheck
 pnpm run lint:autocorrect
 pnpm run test

--- a/apps/playground/index.html
+++ b/apps/playground/index.html
@@ -7,10 +7,7 @@
     <meta name="description" content="" />
     <!-- <link rel="icon" type="image/svg+xml" href="/favicon.svg" /> -->
     <meta name="theme-color" content="" />
-    <link
-      rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/tailwindcss/preflight.css"
-    />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss/preflight.css" />
     <link rel="stylesheet" href="index.css" />
   </head>
 

--- a/cspell.config.mjs
+++ b/cspell.config.mjs
@@ -22,7 +22,6 @@ export default defineConfig({
     '.markdownlintignore',
     '.ncurc',
     '.nvmrc',
-    '.oxfmtrc',
     '.stylelintignore',
     // Git
     'signoff',

--- a/cspell.config.mjs
+++ b/cspell.config.mjs
@@ -22,6 +22,7 @@ export default defineConfig({
     '.markdownlintignore',
     '.ncurc',
     '.nvmrc',
+    '.oxfmtrc',
     '.stylelintignore',
     // Git
     'signoff',
@@ -44,6 +45,7 @@ export default defineConfig({
     'markdownlint',
     'npmjs',
     'numbro',
+    'oxfmt',
     'oxlint',
     'rimraf',
     'sonarjs',

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -2,9 +2,8 @@
  * @type {import('lint-staged').Configuration}
  */
 export default {
-  'package.json': 'sort-package-json',
   '*': [
-    'prettier --write --ignore-unknown',
+    'oxfmt --no-error-on-unmatched-pattern',
     'autocorrect --fix',
     'cspell lint --no-progress --no-must-find-files --dot --gitignore',
   ],

--- a/oxfmt.config.ts
+++ b/oxfmt.config.ts
@@ -2,12 +2,12 @@ import { defineConfig } from 'oxfmt';
 
 export default defineConfig({
   ignorePatterns: [
-    '**/*.min.*',
     '.agents/skills/**',
-    '.codex/skills/**',
     '.claude/skills/**',
+    '.codex/skills/**',
     '.gemini/skills/**',
     '.github/skills/**',
+    '**/*.min.*',
   ],
   singleQuote: true,
   sortImports: true,

--- a/oxfmt.config.ts
+++ b/oxfmt.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'oxfmt';
+
+export default defineConfig({
+  ignorePatterns: ['**/*.min.*'],
+  singleQuote: true,
+  sortImports: true,
+  sortPackageJson: {
+    sortScripts: true,
+  },
+});

--- a/oxfmt.config.ts
+++ b/oxfmt.config.ts
@@ -1,7 +1,14 @@
 import { defineConfig } from 'oxfmt';
 
 export default defineConfig({
-  ignorePatterns: ['**/*.min.*'],
+  ignorePatterns: [
+    '**/*.min.*',
+    '.agents/skills/**',
+    '.codex/skills/**',
+    '.claude/skills/**',
+    '.gemini/skills/**',
+    '.github/skills/**',
+  ],
   singleQuote: true,
   sortImports: true,
   sortPackageJson: {

--- a/package.json
+++ b/package.json
@@ -14,10 +14,6 @@
   "author": "Donnie An",
   "type": "module",
   "scripts": {
-    "format:package-json": "sort-package-json \"**/package.json\" --ignore \"**/node_modules/**/package.json\" --ignore \"**/dist/**/package.json\"",
-    "format:package-json:check": "pnpm run format:package-json --check",
-    "format:prettier": "prettier --write --ignore-unknown .",
-    "format:prettier:check": "prettier --check --ignore-unknown .",
     "lint": "concurrently --group --timings \"pnpm:lint:*(!:fix|^lint:knip$)\" \"pnpm:format:*:check\" \"pnpm:typecheck\"",
     "lint:autocorrect": "autocorrect --lint",
     "lint:autocorrect:fix": "autocorrect --fix",
@@ -41,7 +37,9 @@
     "test:unit:coverage": "vitest run --coverage",
     "test:unit:ui": "vitest --ui",
     "test:unit:watch": "vitest watch",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "format:oxfmt": "oxfmt",
+    "format:oxfmt:check": "oxfmt --check"
   },
   "devDependencies": {
     "@commitlint/cli": "21.0.2",
@@ -59,11 +57,10 @@
     "lint-staged": "17.0.7",
     "markdownlint-cli": "0.48.0",
     "npm-check-updates": "22.2.3",
+    "oxfmt": "0.55.0",
     "oxlint": "1.70.0",
     "oxlint-tsgolint": "0.23.0",
-    "prettier": "3.8.4",
     "serve": "14.2.6",
-    "sort-package-json": "4.0.0",
     "stylelint": "17.13.0",
     "stylelint-config-recess-order": "7.7.0",
     "stylelint-config-standard": "40.0.0",

--- a/package.json
+++ b/package.json
@@ -6,14 +6,16 @@
   "bugs": {
     "url": "https://github.com/donniean/hub/issues"
   },
+  "license": "MIT",
+  "author": "Donnie An",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/donniean/hub.git"
   },
-  "license": "MIT",
-  "author": "Donnie An",
   "type": "module",
   "scripts": {
+    "format:oxfmt": "oxfmt",
+    "format:oxfmt:check": "oxfmt --check",
     "lint": "concurrently --group --timings \"pnpm:lint:*(!:fix|^lint:knip$)\" \"pnpm:format:*:check\" \"pnpm:typecheck\"",
     "lint:autocorrect": "autocorrect --lint",
     "lint:autocorrect:fix": "autocorrect --fix",
@@ -37,9 +39,7 @@
     "test:unit:coverage": "vitest run --coverage",
     "test:unit:ui": "vitest --ui",
     "test:unit:watch": "vitest watch",
-    "typecheck": "tsc --noEmit",
-    "format:oxfmt": "oxfmt",
-    "format:oxfmt:check": "oxfmt --check"
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@commitlint/cli": "21.0.2",
@@ -67,8 +67,8 @@
     "typescript": "5.9.3",
     "vitest": "4.1.9"
   },
-  "packageManager": "pnpm@11.8.0",
   "engines": {
     "node": ">=24.0.0 <25.0.0"
-  }
+  },
+  "packageManager": "pnpm@11.8.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,21 +53,18 @@ importers:
       npm-check-updates:
         specifier: 22.2.3
         version: 22.2.3
+      oxfmt:
+        specifier: 0.55.0
+        version: 0.55.0
       oxlint:
         specifier: 1.70.0
         version: 1.70.0(oxlint-tsgolint@0.23.0)
       oxlint-tsgolint:
         specifier: 0.23.0
         version: 0.23.0
-      prettier:
-        specifier: 3.8.4
-        version: 3.8.4
       serve:
         specifier: 14.2.6
         version: 14.2.6
-      sort-package-json:
-        specifier: 4.0.0
-        version: 4.0.0
       stylelint:
         specifier: 17.13.0
         version: 17.13.0(typescript@5.9.3)
@@ -759,6 +756,128 @@ packages:
 
   '@oxc-resolver/binding-win32-x64-msvc@11.20.0':
     resolution: {integrity: sha512-Wb14jWEW8huH6It9F6sXd9vrYmIS7pMrgkU6sxpLxkP+9z+wRgs71hUEhRpcn8FOXAFa27FVWfY2tRpbfTzfLw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxfmt/binding-android-arm-eabi@0.55.0':
+    resolution: {integrity: sha512-+rFDOqQe5LOWgxrAJaZgLRudr6GQm0wGI6gtu7vVkrdLGjNMUSGbAlaCr8j7F2H2Er97vYQCU8WDb30onqMM1g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxfmt/binding-android-arm64@0.55.0':
+    resolution: {integrity: sha512-ctulLq8s3x8Zmvw6+iccB09TIKERAklRSmbJ10gk8mlAn05qZxoyo52dj3Hi9IJcmDSwF54fQaTVh2CbL6PInw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxfmt/binding-darwin-arm64@0.55.0':
+    resolution: {integrity: sha512-xDQczLH9pw/RBk1h/GH0qcGMm8hQtmtVHBNLSH3lk1gEIR09hZ4L+mJQl4VqiVAvPK9VG9PYrWWuSQLt7xTbiA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxfmt/binding-darwin-x64@0.55.0':
+    resolution: {integrity: sha512-JaNoFCkF2CJdGgpPSMbuO9HVyXyoNGIhMHPvp6NYAjeVKw9XEYc0HcUWJLPQa3Q69WV5wMa9m5jPMJPtbLtcRg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxfmt/binding-freebsd-x64@0.55.0':
+    resolution: {integrity: sha512-DNbszhpg6S2MIzax5azdHFTTBIVkR5xr8yyRZuA4yoDAwOkzIp3tmldgKZM2+VlT+hJIG0xUksA+elISzMEAfA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.55.0':
+    resolution: {integrity: sha512-2snoaoRfFFyGnbOcKUK36rREBYxe/Xgz3uHbiA5zbCB/s6R4DQj4mHqYAaWWhgizCUSDxV8cE9zAZ0XleNpKGw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.55.0':
+    resolution: {integrity: sha512-q1aktHF/WRpSK81BX1dE/9vWrS2jGw1Nax2kb4DBLGAewubCLcoNyp4Zl/NSMgbv3vUS46Z33wIQkBVYOP3PYg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm64-gnu@0.55.0':
+    resolution: {integrity: sha512-VD0y36aENezl/3tsclA/4G53Cc7iV+7Uoh7gz4yvcOTaEYBtJpQsE6PKDGTtUtOvGS4kv51ybfXY/nWZejO5IA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-arm64-musl@0.55.0':
+    resolution: {integrity: sha512-r8xlKJFcsRmn0H5jZrdORae6RX9jDBrZVvOoxF+bCQtampQJClv80aZEHsv+NsLsp2KCE5ql79O7DpPVzYWpXA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.55.0':
+    resolution: {integrity: sha512-GRKv/HXHcwIVld/WU61rF0g0R16hl5EJ+ScKdpjevT57lnLnagj/U2YUbXf2mT+2Pg1uCzWC+mvGicPV3CDdLQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.55.0':
+    resolution: {integrity: sha512-rdv57enTiPtpSYRMKfAiEbQb0Puw5t9N7isVinDoo5qeLDScro2gznmZqSgSWbVZRzLisTeCTW8Qwgw0bOHv3A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-riscv64-musl@0.55.0':
+    resolution: {integrity: sha512-7v1nNrlD43VY6+sYQ6efYyb3lE6QY182304PD/768ZxTjOmFd/3dQa3u/nGBUAXYdGSWOQc5N3PnS0QzUXyEIA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-linux-s390x-gnu@0.55.0':
+    resolution: {integrity: sha512-f4lJLUSPOgScjFl9LiflKCTocyNRwE25JmTMbN4XQdDjoZzEHjqf3wA3VESF1/csg7i8m7+EQLbrZyYDqe10UQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-x64-gnu@0.55.0':
+    resolution: {integrity: sha512-MihqiPziJNoWy4MqNSV+jVA1g+07iQDjZiR0vaCaDoPgFEiJpCMsxamktzLV07cEeQsSJ04vQaU4CzCQwIvtDA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-x64-musl@0.55.0':
+    resolution: {integrity: sha512-Yqghym7KYAVjP9MmSrNZiDeerMuoejNjo0r3ox5H3GDKk8eAfl8VyJm9i+pWCLDCTnAbcTUMMN2ZKjUYXH1v3g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-openharmony-arm64@0.55.0':
+    resolution: {integrity: sha512-s5SDvVVSbyQl1V5UU3Yl12M+XLUQ3rl5SglNqgAA2K4PXUtQhyNSS00wivONPEnNo5W01rCou8WkDNyvI/RGHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxfmt/binding-win32-arm64-msvc@0.55.0':
+    resolution: {integrity: sha512-7p9FB5R32tw2KyyNX3wpQrR2WHwEHvMEiBlGXxeTCaRMCVNx3UtFMAUbaQ/pRNWIrEUZmYhJ6tcUH52uPTRYjQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxfmt/binding-win32-ia32-msvc@0.55.0':
+    resolution: {integrity: sha512-ZYqj3fDnOT1IaVGMP5kpmkQl4F3tQIm2ZyAxvqkJYmI0xgWWak4ss4XYwv3VDfM+TWXeC9K4uQ/wW5jm/5XABA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxfmt/binding-win32-x64-msvc@0.55.0':
+    resolution: {integrity: sha512-eEYT5tivGnGbPHuOHuQpi6CGLObhh0re/5jcNQHihD2GRYkTM85dyi5a19zjP8Q00t1uqAx+/QGLUGdHeqzWyg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
@@ -1459,17 +1578,9 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
-  detect-indent@7.0.2:
-    resolution: {integrity: sha512-y+8xyqdGLL+6sh0tVeHcfP/QDd8gUgbasolJJpY7NgeQGSZ739bDtSiaiDgtoicy+mtYB81dKLxO9xRhCyIB3A==}
-    engines: {node: '>=12.20'}
-
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
-
-  detect-newline@4.0.1:
-    resolution: {integrity: sha512-qE3Veg1YXzGHQhlA6jzebZN2qVf6NX+A7m7qlhCGG30dJixrAQhYOsJjsnBjJkCSmuOPpCk30145fr8FV0bzog==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
@@ -1618,9 +1729,6 @@ packages:
 
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
-
-  git-hooks-list@4.2.1:
-    resolution: {integrity: sha512-WNvqJjOxxs/8ZP9+DWdwWJ7cDsd60NHf39XnD82pDVrKO5q7xfPqpkK6hwEAmBa/ZSEE4IOoR75EzbbIuwGlMw==}
 
   git-raw-commits@5.0.1:
     resolution: {integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==}
@@ -2181,6 +2289,19 @@ packages:
   oxc-resolver@11.20.0:
     resolution: {integrity: sha512-CblytBiV/a/ZXY34dsVU2NxhIOxMXst8CvDCtyBelVITgd7PLrKzbEbA6oKLdPjvDKDzCiW48qzmzZ+mYaqn+g==}
 
+  oxfmt@0.55.0:
+    resolution: {integrity: sha512-jSj2wCTakwgPMxkfiVZX0jf+nX+Nz6xlyAZjqNE0qXTFdCBPYlP6JAN+ODjmealw7DXBjOzYbdsqwBMAZnPZ6A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      svelte: ^5.0.0
+      vite-plus: '*'
+    peerDependenciesMeta:
+      svelte:
+        optional: true
+      vite-plus:
+        optional: true
+
   oxlint-tsgolint@0.23.0:
     resolution: {integrity: sha512-3mBv3CoPbh8dFbzfDGIWa2ytZjn2v+3EX4aKRXjIhsoGFzG8GCjfRirz3rwZf1wYbZzsNLTSgpw8VjQuWdp/jA==}
     hasBin: true
@@ -2254,11 +2375,6 @@ packages:
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
-
-  prettier@3.8.4:
-    resolution: {integrity: sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==}
-    engines: {node: '>=14'}
-    hasBin: true
 
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
@@ -2396,14 +2512,6 @@ packages:
     resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
     engines: {node: '>= 18'}
 
-  sort-object-keys@2.1.0:
-    resolution: {integrity: sha512-SOiEnthkJKPv2L6ec6HMwhUcN0/lppkeYuN1x63PbyPRrgSPIuBJCiYxYyvWRTtjMlOi14vQUCGUJqS6PLVm8g==}
-
-  sort-package-json@4.0.0:
-    resolution: {integrity: sha512-6aYOlYI9AWioZ+rzu+4zKLmoFqJP0/fHDxrd7X04yqEibikY+5YVF0EYlyGn4v6X2PJY7yAUWV7oeP+i5rOm/g==}
-    engines: {node: '>=22'}
-    hasBin: true
-
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -2520,6 +2628,10 @@ packages:
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@2.1.0:
+    resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
+    engines: {node: ^20.0.0 || >=22.0.0}
 
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
@@ -3309,6 +3421,63 @@ snapshots:
   '@oxc-resolver/binding-win32-x64-msvc@11.20.0':
     optional: true
 
+  '@oxfmt/binding-android-arm-eabi@0.55.0':
+    optional: true
+
+  '@oxfmt/binding-android-arm64@0.55.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-arm64@0.55.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-x64@0.55.0':
+    optional: true
+
+  '@oxfmt/binding-freebsd-x64@0.55.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.55.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.55.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-gnu@0.55.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-musl@0.55.0':
+    optional: true
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.55.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.55.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-musl@0.55.0':
+    optional: true
+
+  '@oxfmt/binding-linux-s390x-gnu@0.55.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-gnu@0.55.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-musl@0.55.0':
+    optional: true
+
+  '@oxfmt/binding-openharmony-arm64@0.55.0':
+    optional: true
+
+  '@oxfmt/binding-win32-arm64-msvc@0.55.0':
+    optional: true
+
+  '@oxfmt/binding-win32-ia32-msvc@0.55.0':
+    optional: true
+
+  '@oxfmt/binding-win32-x64-msvc@0.55.0':
+    optional: true
+
   '@oxlint-tsgolint/darwin-arm64@0.23.0':
     optional: true
 
@@ -3917,11 +4086,7 @@ snapshots:
 
   dequal@2.0.3: {}
 
-  detect-indent@7.0.2: {}
-
   detect-libc@2.1.2: {}
-
-  detect-newline@4.0.1: {}
 
   devlop@1.1.0:
     dependencies:
@@ -4047,8 +4212,6 @@ snapshots:
   get-tsconfig@4.14.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
-
-  git-hooks-list@4.2.1: {}
 
   git-raw-commits@5.0.1(conventional-commits-parser@6.4.0):
     dependencies:
@@ -4676,6 +4839,30 @@ snapshots:
       '@oxc-resolver/binding-win32-arm64-msvc': 11.20.0
       '@oxc-resolver/binding-win32-x64-msvc': 11.20.0
 
+  oxfmt@0.55.0:
+    dependencies:
+      tinypool: 2.1.0
+    optionalDependencies:
+      '@oxfmt/binding-android-arm-eabi': 0.55.0
+      '@oxfmt/binding-android-arm64': 0.55.0
+      '@oxfmt/binding-darwin-arm64': 0.55.0
+      '@oxfmt/binding-darwin-x64': 0.55.0
+      '@oxfmt/binding-freebsd-x64': 0.55.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.55.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.55.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.55.0
+      '@oxfmt/binding-linux-arm64-musl': 0.55.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.55.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.55.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.55.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.55.0
+      '@oxfmt/binding-linux-x64-gnu': 0.55.0
+      '@oxfmt/binding-linux-x64-musl': 0.55.0
+      '@oxfmt/binding-openharmony-arm64': 0.55.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.55.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.55.0
+      '@oxfmt/binding-win32-x64-msvc': 0.55.0
+
   oxlint-tsgolint@0.23.0:
     optionalDependencies:
       '@oxlint-tsgolint/darwin-arm64': 0.23.0
@@ -4763,8 +4950,6 @@ snapshots:
       nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
-
-  prettier@3.8.4: {}
 
   prompts@2.4.2:
     dependencies:
@@ -4922,18 +5107,6 @@ snapshots:
 
   smol-toml@1.6.1: {}
 
-  sort-object-keys@2.1.0: {}
-
-  sort-package-json@4.0.0:
-    dependencies:
-      detect-indent: 7.0.2
-      detect-newline: 4.0.1
-      git-hooks-list: 4.2.1
-      is-plain-obj: 4.1.0
-      semver: 7.8.4
-      sort-object-keys: 2.1.0
-      tinyglobby: 0.2.17
-
   source-map-js@1.2.1: {}
 
   stackback@0.0.2: {}
@@ -5076,6 +5249,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinypool@2.1.0: {}
 
   tinyrainbow@3.1.0: {}
 

--- a/prettier.config.mjs
+++ b/prettier.config.mjs
@@ -1,4 +1,0 @@
-/** @type {import('prettier').Config} */
-export default {
-  singleQuote: true,
-};

--- a/snippets/promise/index.js
+++ b/snippets/promise/index.js
@@ -48,17 +48,11 @@ class CustomPromise {
       this.rejectedCallbacks.push(onRejected);
     }
 
-    if (
-      this.status === STATUS_MAP.FULFILLED &&
-      typeof onFulfilled === 'function'
-    ) {
+    if (this.status === STATUS_MAP.FULFILLED && typeof onFulfilled === 'function') {
       onFulfilled(this.value);
     }
 
-    if (
-      this.status === STATUS_MAP.REJECTED &&
-      typeof onRejected === 'function'
-    ) {
+    if (this.status === STATUS_MAP.REJECTED && typeof onRejected === 'function') {
       onRejected(this.reason);
     }
 

--- a/snippets/promise/methods.js
+++ b/snippets/promise/methods.js
@@ -53,10 +53,7 @@ Promise.last = function last(promises = []) {
 
 Promise.none = function none(promises) {
   const list = promises.map(
-    (promise) =>
-      new Promise((resolve, reject) =>
-        Promise.resolve(promise).then(reject, resolve),
-      ),
+    (promise) => new Promise((resolve, reject) => Promise.resolve(promise).then(reject, resolve)),
   );
 
   return Promise.all(list);
@@ -138,14 +135,7 @@ const promise300 = sleep(true, 300);
 const promise400 = sleep(true, 400);
 const promise500 = sleep(false, 500);
 const promise600 = sleep(true, 600);
-const promises = [
-  promise600,
-  promise200,
-  promise500,
-  promise300,
-  promise400,
-  promise100,
-];
+const promises = [promise600, promise200, promise500, promise300, promise400, promise100];
 
 Promise.first(promises)
   .then((value) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -44,13 +44,7 @@
     /* node */
 
     /* Language and Environment */
-    "lib": [
-      "ES2024",
-      "ESNext.Array",
-      "ESNext.Collection",
-      "ESNext.Iterator",
-      "ESNext.Promise"
-    ],
+    "lib": ["ES2024", "ESNext.Array", "ESNext.Collection", "ESNext.Iterator", "ESNext.Promise"],
 
     /* Modules */
     "module": "preserve",


### PR DESCRIPTION
## Summary

- Replace Prettier and `sort-package-json` with Oxfmt for formatting and package.json sorting.
- Add Oxfmt editor recommendations and update CI, lint-staged, documentation, spelling configuration, and package metadata.
- Remove the old Prettier config and ignore file.
- Apply the Oxfmt write pass after the migration.

## Validation

- `pnpm run format:oxfmt`
- `pnpm run format:oxfmt:check`
- `git diff --check`

## Notes for Reviewers

- Current PR diff: 16 files changed.
- This is intended to be a tooling and formatting-only migration; no runtime behavior changes are intended.
