### PR TITLE
style(lint): update import and export lint conventions

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -65,6 +65,12 @@ export default defineConfig({
     'eslint/no-var': 'error',
     'eslint/prefer-const': 'error',
     'eslint/prefer-template': 'error',
+    'eslint/sort-imports': [
+      'error',
+      {
+        ignoreDeclarationSort: true,
+      },
+    ],
     'import/first': 'error',
     'import/newline-after-import': 'error',
     'import/no-cycle': 'error',
@@ -72,10 +78,23 @@ export default defineConfig({
       'error',
       {
         considerQueryString: true,
+        preferInline: true,
       },
     ],
-    'typescript/consistent-type-exports': 'error',
-    'typescript/consistent-type-imports': 'error',
+    'typescript/consistent-type-exports': [
+      'error',
+      {
+        fixMixedExportsWithInlineTypeSpecifier: true,
+      },
+    ],
+    'typescript/consistent-type-imports': [
+      'error',
+      {
+        prefer: 'type-imports',
+        fixStyle: 'inline-type-imports',
+        disallowTypeAnnotations: true,
+      },
+    ],
     'typescript/no-empty-object-type': 'error',
     'typescript/no-explicit-any': 'error',
     'typescript/no-import-type-side-effects': 'error',


### PR DESCRIPTION
## Summary

- Configure Oxlint to prefer inline type specifiers for mixed imports and exports.
- Enable named import member sorting while leaving import declaration ordering to Oxfmt.
- Leave default-export policy outside this config change.

## Validation

- `pnpm exec oxlint oxlint.config.ts`
- `pnpm run format:oxfmt:check`
- `pnpm run typecheck`

`pnpm run lint:oxlint` is still blocked by existing legacy snippet diagnostics outside this change.
