### PR TITLE
chore(knip): include knip in lint scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ pnpm run test
 pnpm run test:unit
 ```
 
-`pnpm run lint` includes `lint:oxlint`. `lint:oxlint` is not part of the current default validation for legacy snippets; the long-term target is to fix those snippets or migrate them to TypeScript so they meet the JavaScript linting standard.
+`pnpm run lint` includes `lint:knip` and `lint:oxlint`. `lint:oxlint` is not part of the current default validation for legacy snippets; the long-term target is to fix those snippets or migrate them to TypeScript so they meet the JavaScript linting standard.
 
 If check results can be fixed automatically, prefer the smallest relevant `fix` command instead of running a full-repository fix indiscriminately.
 
@@ -75,6 +75,7 @@ Matching `fix` commands include:
 
 - `pnpm run format:oxfmt`
 - `pnpm run lint:autocorrect:fix`
+- `pnpm run lint:knip:fix`
 - `pnpm run lint:oxlint:fix`
 - `pnpm run lint:markdown:fix`
 - `pnpm run lint:styles:fix`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,7 @@ Use smaller checks by file type when possible:
 ```bash
 pnpm run format:oxfmt:check
 pnpm run lint:autocorrect
+pnpm run lint:knip
 pnpm run lint:oxlint
 pnpm run lint:html
 pnpm run lint:markdown

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ pnpm run test:unit:ui
 pnpm run serve
 ```
 
-`pnpm run lint` includes `lint:oxlint`. `lint:oxlint` is not part of the current default validation for legacy snippets; the long-term target is to fix those snippets or migrate them to TypeScript so they meet the JavaScript linting standard.
+`pnpm run lint` includes `lint:knip` and `lint:oxlint`. `lint:oxlint` is not part of the current default validation for legacy snippets; the long-term target is to fix those snippets or migrate them to TypeScript so they meet the JavaScript linting standard.
 
 `pnpm run serve` starts a static server for [`apps/playground/`](apps/playground/).
 

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -1,0 +1,7 @@
+import type { KnipConfig } from 'knip';
+
+const config = {
+  entry: ['.htmlvalidate.mjs', '.ncurc.mjs', 'apps/playground/index.js', 'snippets/**/*.js'],
+} as const satisfies KnipConfig;
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
   "scripts": {
     "format:oxfmt": "oxfmt",
     "format:oxfmt:check": "oxfmt --check",
-    "lint": "concurrently --group --timings \"pnpm:lint:*(!:fix|^lint:knip$)\" \"pnpm:format:*:check\" \"pnpm:typecheck\"",
+    "lint": "concurrently --group --timings \"pnpm:lint:*(!:fix)\" \"pnpm:format:*:check\" \"pnpm:typecheck\"",
     "lint:autocorrect": "autocorrect --lint",
     "lint:autocorrect:fix": "autocorrect --fix",
-    "lint:fix": "concurrently --max-processes=1 --group --timings \"pnpm:lint:*:fix(!^lint:knip:fix$)\" \"pnpm:format:*(!:check)\"",
+    "lint:fix": "concurrently --max-processes=1 --group --timings \"pnpm:lint:*:fix\" \"pnpm:format:*(!:check)\"",
     "lint:html": "html-validate \"**/*.html\"",
     "lint:knip": "knip",
     "lint:knip:fix": "knip --fix",


### PR DESCRIPTION
## Summary

- Add a typed Knip configuration for standalone playground and snippet entry points.
- Include `lint:knip` in the aggregate `lint` script.
- Include `lint:knip:fix` in the aggregate `lint:fix` script.
- Update README and agent guidance for the expanded lint workflow and focused Knip checks.

## Rationale

Knip now has a repository-specific config for standalone scripts that are intentionally not imported by an application entry point. This allows Knip to run as part of the normal lint workflow.

## Validation

- `pnpm run lint:knip`
- `pnpm run format:oxfmt:check`
- `pnpm run lint:markdown`
- `pnpm run lint:spellcheck`
- `pnpm run lint:autocorrect`
- `pnpm run test`

## Notes

- `pnpm run lint` still fails on existing `lint:oxlint` issues in legacy snippets; this PR does not change that existing lint debt.
