### PR TITLE
chore: refresh pnpm allow builds

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,3 @@
-allowBuilds:
-  unrs-resolver: true
 engineStrict: true
 minimumReleaseAge: 1440
 saveExact: true


### PR DESCRIPTION
Refresh pnpm build approvals against the current locked dependency graph. Remove stale package entries, preserve existing decisions for remaining locked dependencies, and approve newly pending builds. Generated by `scripts/update/pnpm-allow-builds.sh`.