### PR TITLE
ci: cancel stale workflow runs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/pull-requests.auto-merge.yaml
+++ b/.github/workflows/pull-requests.auto-merge.yaml
@@ -3,6 +3,10 @@ on:
   workflow_call:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/pull-requests.auto-update.yaml
+++ b/.github/workflows/pull-requests.auto-update.yaml
@@ -11,6 +11,10 @@ on:
         required: true
   push:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:


### PR DESCRIPTION
## Summary

- cancel stale CI runs for the same ref
- cancel stale pull request auto-merge and auto-update runs in the reusable workflows
- keep dependency bump runs non-cancelable because they can create commits and pull requests

## Impact

New runs for the same workflow and ref replace obsolete in-progress runs, reducing wasted GitHub Actions time without interrupting dependency-update side effects.

## Validation

- `yq eval '.'` for all workflow YAML files
- `pnpm run format:oxfmt:check`
- repository pre-commit checks