### PR TITLE
docs(tooling): update staged oxlint example

### DIFF
--- a/lint-staged.config.ts
+++ b/lint-staged.config.ts
@@ -7,7 +7,7 @@ export default {
     'cspell --no-progress --dot --gitignore --no-must-find-files',
   ],
   // '*.{ts,tsx,mts,cts}': [() => 'tsc --noEmit', 'vitest related --run'],
-  // '*.{js,jsx,mjs,cjs,ts,tsx,mts,cts}': 'oxlint --fix',
+  // '*.{js,jsx,mjs,cjs,ts,tsx,mts,cts}': 'oxlint --fix --no-error-on-unmatched-pattern',
   '*.css': 'stylelint --fix',
   '*.html': 'html-validate',
   '*.md': 'markdownlint --dot --fix',


### PR DESCRIPTION
## Summary

- update the disabled staged Oxlint example to tolerate empty lint inputs
- keep the example aligned with the active configurations used by related projects

## Why

If the example is enabled later, `lint-staged` may pass paths that Oxlint excludes. `--no-error-on-unmatched-pattern` keeps that valid no-op from blocking a commit while preserving failures for actual lint diagnostics.

## Validation

- `pnpm run format:oxfmt:check`
- `pnpm run lint:spellcheck`
- `pnpm run lint:autocorrect`
- pre-commit `lint-staged` hook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **其他**
  * 优化代码检查配置，避免在没有匹配文件时产生错误提示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->