### PR TITLE
fix(scripts): reset pnpm install state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ Impact summary:
 - [`scripts/update/brew.sh`](scripts/update/brew.sh) runs Homebrew update, upgrade, and cleanup tasks, and removes dependencies that are no longer needed.
 - [`scripts/update/mas.sh`](scripts/update/mas.sh) upgrades Mac App Store apps.
 - [`scripts/update/npm-global.sh`](scripts/update/npm-global.sh) updates global npm packages.
-- [`scripts/update/pnpm-allow-builds.sh`](scripts/update/pnpm-allow-builds.sh) resets pnpm build approvals in the configured local repositories, reinstalls dependencies without a frozen lockfile, approves all discovered builds, commits and pushes all resulting changes, creates pull requests and opens their pages in the browser, and force-deletes the local update branches.
+- [`scripts/update/pnpm-allow-builds.sh`](scripts/update/pnpm-allow-builds.sh) resets pnpm build approvals in the configured local repositories, removes existing `node_modules` directories and `pnpm-lock.yaml` files, reinstalls dependencies without a frozen lockfile, approves all discovered builds, commits and pushes all resulting changes, creates pull requests and opens their pages in the browser, and force-deletes the local update branches.
 - [`scripts/update/skills.sh`](scripts/update/skills.sh) updates global skills.
 - [`scripts/update/repos.sh`](scripts/update/repos.sh) switches the local repositories listed in the script to `main`, pulls changes, and installs dependencies.
 - [`scripts/cleanup/codex.sh`](scripts/cleanup/codex.sh) deletes the local Codex output directories listed in the script.

--- a/scripts/update/pnpm-allow-builds.sh
+++ b/scripts/update/pnpm-allow-builds.sh
@@ -45,7 +45,8 @@ for repo_name in "${repo_names[@]}"; do
     git pull --all --prune
     git switch --create "${head_branch_name}"
 
-    rm -rf node_modules/
+    find . -type d -name node_modules -prune -exec rm -rf {} +
+    find . -type f -name pnpm-lock.yaml -delete
     pnpm config delete --location=project allowBuilds
     pnpm install --no-frozen-lockfile --config.strictDepBuilds=false
     pnpm approve-builds --all


### PR DESCRIPTION
## Summary

- remove root and nested `node_modules` directories before refreshing pnpm build approvals
- remove root and nested `pnpm-lock.yaml` files so the install regenerates dependency state
- document the expanded destructive impact of the maintenance script

## Why

The script previously removed only the repository-root `node_modules` directory. Workspaces can retain nested install state and lockfiles, which prevents the build-approval refresh from starting from a consistently clean pnpm state.

## Impact

Running `scripts/update/pnpm-allow-builds.sh` now regenerates lockfiles as well as installed dependencies in each configured repository. The script remains opt-in and was not executed as part of this change.

## Validation

- `bash -n scripts/update/pnpm-allow-builds.sh`
- isolated root and nested target-selection test for both `node_modules` and `pnpm-lock.yaml`
- `pnpm run lint:markdown`
- `pnpm run format:oxfmt:check`
- `pnpm run lint:autocorrect`
- `pnpm run lint:spellcheck`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 更新安装前清理行为说明，明确会删除现有的 `node_modules` 目录和 `pnpm-lock.yaml` 文件。

* **维护**
  * 安装前会递归清理所有 `node_modules` 目录及 `pnpm-lock.yaml` 文件，确保依赖环境更加一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->