### PR TITLE
fix(scripts): limit pnpm cleanup scope

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ Impact summary:
 - [`scripts/update/brew.sh`](scripts/update/brew.sh) runs Homebrew update, upgrade, and cleanup tasks, and removes dependencies that are no longer needed.
 - [`scripts/update/mas.sh`](scripts/update/mas.sh) upgrades Mac App Store apps.
 - [`scripts/update/npm-global.sh`](scripts/update/npm-global.sh) updates global npm packages.
-- [`scripts/update/pnpm-allow-builds.sh`](scripts/update/pnpm-allow-builds.sh) resets pnpm build approvals in the configured local repositories, removes existing `node_modules` directories and `pnpm-lock.yaml` files, reinstalls dependencies without a frozen lockfile, approves all discovered builds, commits and pushes all resulting changes, creates pull requests and opens their pages in the browser, and force-deletes the local update branches.
+- [`scripts/update/pnpm-allow-builds.sh`](scripts/update/pnpm-allow-builds.sh) resets pnpm build approvals in the configured local repositories, removes the repository-root `node_modules` directory and `pnpm-lock.yaml` file, reinstalls dependencies without a frozen lockfile, approves all discovered builds, commits and pushes all resulting changes, creates pull requests and opens their pages in the browser, and force-deletes the local update branches.
 - [`scripts/update/skills.sh`](scripts/update/skills.sh) updates global skills.
 - [`scripts/update/repos.sh`](scripts/update/repos.sh) switches the local repositories listed in the script to `main`, pulls changes, and installs dependencies.
 - [`scripts/cleanup/codex.sh`](scripts/cleanup/codex.sh) deletes the local Codex output directories listed in the script.

--- a/scripts/update/pnpm-allow-builds.sh
+++ b/scripts/update/pnpm-allow-builds.sh
@@ -45,8 +45,7 @@ for repo_name in "${repo_names[@]}"; do
     git pull --all --prune
     git switch --create "${head_branch_name}"
 
-    find . -type d -name node_modules -prune -exec rm -rf {} +
-    find . -type f -name pnpm-lock.yaml -delete
+    rm -rf node_modules/ pnpm-lock.yaml
     pnpm config delete --location=project allowBuilds
     pnpm install --no-frozen-lockfile --config.strictDepBuilds=false
     pnpm approve-builds --all


### PR DESCRIPTION
## Summary

- limit pnpm refresh cleanup to the repository-root `node_modules` directory and `pnpm-lock.yaml` file
- keep nested workspace install state and lockfiles untouched
- update the maintenance-script impact documentation to match the narrower scope

## Why

The previous recursive cleanup removed dependency state throughout each configured repository. The refresh only needs to reset the repository-root pnpm state, so recursively deleting nested paths is unnecessarily broad.

## Impact

Running `scripts/update/pnpm-allow-builds.sh` now removes only `node_modules/` and `pnpm-lock.yaml` in the root of each configured repository before reinstalling dependencies. The maintenance script itself was not executed as part of this change.

## Validation

- `bash -n scripts/update/pnpm-allow-builds.sh`
- `pnpm run lint:markdown`
- `pnpm run format:oxfmt:check`
- `pnpm run lint:autocorrect`
- `pnpm run lint:spellcheck`
- `git diff --check`
